### PR TITLE
Transfer S3 to GCS tool

### DIFF
--- a/transfer_s3_to_gcs/README.md
+++ b/transfer_s3_to_gcs/README.md
@@ -190,19 +190,6 @@ transferSpec:
 </details>
 <br>
 
-<!-- ## Output -->
-<!-- 
-A TSV file will be generated locally and uploaded to the S3 bucket. The manifest will look something like the following:
-
-| input_file_path                                            | file_name                                                  | s3_file_size | s3_md5sum                           | md5sum                           | s3_path                                                    | s3_modified_date          | guid                                         | ga4gh_drs_uri                                                |
-| ---------------------------------------------------------- | ---------------------------------------------------------- | ------------ | ----------------------------------- | -------------------------------- | ---------------------------------------------------------- | ------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
-| s3://rti-test-bucket/aggregate-all-proj-billing-report.csv | s3://rti-test-bucket/aggregate-all-proj-billing-report.csv | 509754247    | dbf2a67bfc6b609363f99bcf8d0c3799-30 | b1f79144c782e699e004e78f2da099e7 | s3://rti-test-bucket/aggregate-all-proj-billing-report.csv | 2020-01-01 21:05:40+00:00 | dg.1212/0e0877ba-731b-4ce9-b266-34b71e6d6322 | drs://dg.1212:dg.1212%2F0e0877ba-731b-4ce9-b266-34b71e6d6322 |
-| s3://rti-test-bucket/billing-budget-alert-email.png        | s3://rti-test-bucket/billing-budget-alert-email.png        | 1345755      | 2992b062c8ce8876cdcc552e233c6c3c    | 2992b062c8ce8876cdcc552e233c6c3c | s3://rti-test-bucket/billing-budget-alert-email.png        | 2020-01-01 21:05:52+00:00 | dg.1212/dfafc275-1206-4684-8368-512b4ae479ec | drs://dg.1212:dg.1212%2Fdfafc275-1206-4684-8368-512b4ae479ec |
-| s3://rti-test-bucket/var_report.xml                        | s3://rti-test-bucket/var_report.xml                        | 1380403      | 7845dda8786244538b5ebb826021af1d    | 7845dda8786244538b5ebb826021af1d | s3://rti-test-bucket/var_report.xml                        | 2020-01-01 21:05:56+00:00 | dg.1212/14cccdae-c671-4abe-b1fd-b288b15eff38 | drs://dg.1212:dg.1212%2F14cccdae-c671-4abe-b1fd-b288b15eff38 |
-| s3://rti-test-bucket/test.txt.gz                           | s3://rti-test-bucket/test.txt.gz                           | 924487       | e18ece94da761771c8bbdb9b8be3d0db    | e18ece94da761771c8bbdb9b8be3d0db | s3://rti-test-bucket/test.txt.gz                           | 2020-01-01 21:06:00+00:00 | dg.1212/e2ac1985-db23-4bfe-bfe1-07a476177c66 | drs://dg.1212:dg.1212%2Fe2ac1985-db23-4bfe-bfe1-07a476177c66 |
-| s3://rti-test-bucket/test.txt                              | s3://rti-test-bucket/test.txt                              | 79580051     | bc98ca9dfb02a387703603a447644e94-5  | 6ae3f98be14578ea5b3c6c712a442408 | s3://rti-test-bucket/test.txt                              | 2020-01-01 21:05:40+00:00 | dg.1212/5ee01ada-1f63-40ef-a6b2-dc3ce2aa0a03 | drs://dg.1212:dg.1212%2F5ee01ada-1f63-40ef-a6b2-dc3ce2aa0a03 | 
--->
-
 ## Reference
 Some helpful resources in troubleshooting common problems with the Google service account.
 

--- a/transfer_s3_to_gcs/README.md
+++ b/transfer_s3_to_gcs/README.md
@@ -1,0 +1,216 @@
+# Transfer S3 to Google Storage
+
+## Overview
+This Dockerfile sets up an environment to create a transfer job (using Google's Cloud Storage Transfer Service) via a Google service account which ultimately results in creating a Google Storage (GS) bucket that mirrors a AWS S3 bucket.
+
+## Setup
+
+In order to leverage this tool, you must have a [Google service account](https://cloud.google.com/iam/docs/service-account-overview) set up. 
+- Specifically, a [user-managed service account](https://cloud.google.com/iam/docs/service-account-types#user-managed) is needed.
+    - When you creating a user-managed service account in a Google project, a name for the service account is chosen and it appears in the email address that identifies the service account using the following format: `<SERVICE-ACCOUNT-NAME>@<PROJECT-ID>.iam.gserviceaccount.com`
+
+- AWS roles and Google Cloud service accounts are similar in that they both provide ways to delegate permissions and manage access control within their respective cloud environments. Both are used to grant specific permissions to applications, services, or users, allowing them to perform tasks that require access to resources within the cloud environments.
+
+[Application Default Credentials (ADC)](https://cloud.google.com/iam/docs/service-account-creds) are used for authenticating the service account.
+- Step-by-step instructions for creating a ADC file can be found [here](https://cloud.google.com/docs/authentication/provide-credentials-adc). 
+
+For best practices for using service accounts, please see the [documentation](https://cloud.google.com/iam/docs/best-practices-service-accounts).
+
+
+## Usage
+
+### Setup
+`entrypoint.sh` will configure AWS CLI and activate the Google service account. 
+If a [AWS credential file](https://github.com/aws/aws-cli) is available (e.g., `~/.aws/credentials`), the quickest way to get started is to pass those credentials in as environment variables.
+
+```
+export AWS_PROFILE="<PROFILE_NAME>" 
+export AWS_ACCESS_KEY_ID=$(aws configure get ${AWS_PROFILE}.aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get ${AWS_PROFILE}.aws_secret_access_key)
+export AWS_DEFAULT_REGION=$(aws configure get ${AWS_PROFILE}.default_region)
+```
+- Replace `<PROFILE_NAME>` with the section name within the INI-formatted credentials file.
+
+Then, set `GC_PROJECT` to the name of the Google Cloud project: `export GC_PROJECT="rti-gcp-test-project"`
+
+Then, set `S3_BUCKET` environment variable to the name of the S3 bucket that will be copied, without the `s3://` prefix: `export S3_BUCKET="rti-test-bucket"`
+
+### Running the image as a container
+Finally, set an environment variable `PATH_TO_ADC_JSON` as the local system path of the [Application Default Credential file](#setup) generated for the service account: `export PATH_TO_ADC_JSON="/path/to/adc.json"`
+
+Then run the following Docker run command:
+```
+docker run \
+  -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  -e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+  -e GC_ADC_FILE="/opt/adc.json" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e GC_PROJECT="$GC_PROJECT" \
+  --mount type=bind,source="$PATH_TO_ADC_JSON",target="/opt/adc.json" \
+  --rm -it <IMAGE_NAME>
+```
+- Replace `<IMAGE_NAME>` with the `image:tag` created from the Dockerfile.
+
+Alternatively, if the credential file cannot be passed in, set an environment variable `$ADC_JSON` to the contents of the credential file (e.g. json) as a string.
+
+```
+export ADC_JSON="{    \"type\": \"service_account\",    \"project_id\": \"rti-gcp-test-project\",    \"private_key_id\": \"abcdefghijlkmnopqrstuvwxyz\",    \"private_key\": \"-----BEGIN PRIVATE KEY-----\n987654321abcdefgh\n-----END PRIVATE KEY-----\n\",    \"client_email\": \"rti-srvc-accnt@rti-gcp-test-project.iam.gserviceaccount.com\",    \"client_id\": \"113491005989622502054\",    \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",    \"token_uri\": \"https://oauth2.googleapis.com/token\",    \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",    \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/rti-srvc-accnt%40rti-gcp-test-project.iam.gserviceaccount.com\",    \"universe_domain\": \"googleapis.com\"  }"
+```
+
+and run the following Docker run command:
+```
+docker run \
+  -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  -e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+  -e GC_ADC_JSON="$ADC_JSON" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e GC_PROJECT="$GC_PROJECT" \
+  -it <IMAGE_NAME>
+```
+
+
+## Build
+The following command can be used to build this Docker image, following command:
+```
+docker build -rm -t transfer_s3_to_gcs:v1.0 .`
+```
+Here's what each part of the command does:
+
+`docker build`: This command tells Docker to build an image.
+
+`--rm`: This flag removes any intermediate containers that are created during the build process, helping to keep your system clean.
+
+`-t transfer_s3_to_gcs:v1.0`: The -t flag specifies the name and tag for the image. In this case, it's named transfer_s3_to_gcs with version v1.0.
+
+`-f Dockerfile`: This flag specifies the Dockerfile to use for building the image. It's the default so not needed.
+
+`.`: The dot at the end of the command indicates that the build context is the current directory, where the Dockerfile is located.
+
+Running this command will build a Docker image with the name `transfer_s3_to_gcs:v1.0`. Make sure the build occurs in the the directory containing the Dockerfile used for building the image.
+
+
+## Perform a testrun
+
+```
+export AWS_PROFILE="nhlbibdc" 
+export AWS_ACCESS_KEY_ID=$(aws configure get ${AWS_PROFILE}.aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get ${AWS_PROFILE}.aws_secret_access_key)
+export AWS_DEFAULT_REGION=$(aws configure get ${AWS_PROFILE}.default_region)
+export S3_BUCKET="rti-test-bucket"
+export GC_PROJECT="rti-gcp-test-project"
+export PATH_TO_ADC_JSON="/local/path/to/rti-access.json"
+
+docker run \
+  -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  -e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+  -e GC_ADC_FILE="/opt/adc.json" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e GC_PROJECT="$GC_PROJECT" \
+  --mount type=bind,source="$PATH_TO_ADC_JSON",target="/opt/adc.json" \
+  --rm -it transfer_s3_to_gcs:v1.0
+```
+
+When the service account credential file cannot be passed in, pass in the credential json as string `$ADC_JSON`.
+```
+export AWS_PROFILE="nhlbibdc" 
+export AWS_ACCESS_KEY_ID=$(aws configure get ${AWS_PROFILE}.aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get ${AWS_PROFILE}.aws_secret_access_key)
+export AWS_DEFAULT_REGION=$(aws configure get ${AWS_PROFILE}.default_region)
+export S3_BUCKET="rti-test-bucket"
+export GC_PROJECT="rti-gcp-test-project
+export ADC_JSON="{    \"type\": \"service_account\",    \"project_id\": \"rti-gcp-test-project\",    \"private_key_id\": \"abcdefghijlkmnopqrstuvwxyz\",    \"private_key\": \"-----BEGIN PRIVATE KEY-----\n987654321abcdefgh\n-----END PRIVATE KEY-----\n\",    \"client_email\": \"rti-srvc-accnt@rti-gcp-test-project.iam.gserviceaccount.com\",    \"client_id\": \"113491005989622502054\",    \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",    \"token_uri\": \"https://oauth2.googleapis.com/token\",    \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",    \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/rti-srvc-accnt%40rti-gcp-test-project.iam.gserviceaccount.com\",    \"universe_domain\": \"googleapis.com\"  }"
+
+
+docker run \
+  -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  -e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+  -e GC_ADC_JSON="$ADC_JSON" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e GC_PROJECT="$GC_PROJECT" \
+  -it transfer_s3_to_gcs:v1.0
+```
+
+From within the interactive session, trigger `entrypoint.sh` to 1.) activate the Google Service Account, and 2.) create a Google transfer job.
+- Verify credentials were applied by running `gcloud auth list`
+
+A transfer job can be created one time for each Google Storage bucket. If a job needs to be repeated, the transfer job must be deleted from the operations list.
+In order to do that:
+1. set project name for gcloud to the project name ( `gcloud config set project "$GC_PROJECT"` )
+2. find the name of the transfer job ( `gcloud transfer operations list` )
+3. delete the transfer job ( `gcloud transfer job delete <NAME_OF_JOB>`)
+Once complete, you can initiate a new transfer job by rerunning `bash /opt/entrypoint.sh`
+
+Transfer jobs can be monitored through `gcloud transfer operations list`.
+Once the job is complete, Google Storage buckets can be examined with `gsutil ls -r $S3_BUCKET`
+
+<details>
+
+```
+[[ configure_aws_cli.sh ]]
+>>> Configuring aws cli...
+[[ aws s3 - copy most recently generated manifest .tsv from s3://rti-test-bucket]]
+download: s3://rti-test-bucket/rti-test.manifest.20240508150623.tsv to ./rti-test.manifest.20240508150623.tsv
+Pulled {rti-test.manifest.20240508150623.tsv}
+--- GC_ADC_JSON detected ---
+[[ Create Google Service Account key file ]]
+[[ Activating Google Cloud service account ]]
+Activated service account credentials for: [rti-srvc-accnt@rti-gcp-test-project.iam.gserviceaccount.com]
+[[ Create temporary AWScreds.txt file ]]
+[[ Initiate transfer from s3:// to gs://rti-test-bucket ]]
+creationTime: '2024-05-08T16:33:30.446605065Z'
+description: rti-test-bucket
+lastModificationTime: '2024-05-08T16:33:30.446605065Z'
+loggingConfig: {}
+name: transferJobs/rti-test-bucket
+projectId: rti-gcp-test-project
+schedule:
+  scheduleEndDate:
+    day: 8
+    month: 5
+    year: 2024
+  scheduleStartDate:
+    day: 8
+    month: 5
+    year: 2024
+status: ENABLED
+transferSpec:
+  awsS3DataSource:
+    bucketName: rti-test-bucket
+  gcsDataSink:
+    bucketName: rti-test-bucket
+[[ Cleanup AWScreds.txt file ]]
+[[ List manifest files in gs://rti-test-bucket ]]
+[[ List all objects in gs://rti-test-bucket ]]
+[[ Cleanup Google Service Account key file ]]
+```
+</details>
+<br>
+
+<!-- ## Output -->
+<!-- 
+A TSV file will be generated locally and uploaded to the S3 bucket. The manifest will look something like the following:
+
+| input_file_path                                            | file_name                                                  | s3_file_size | s3_md5sum                           | md5sum                           | s3_path                                                    | s3_modified_date          | guid                                         | ga4gh_drs_uri                                                |
+| ---------------------------------------------------------- | ---------------------------------------------------------- | ------------ | ----------------------------------- | -------------------------------- | ---------------------------------------------------------- | ------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
+| s3://rti-test-bucket/aggregate-all-proj-billing-report.csv | s3://rti-test-bucket/aggregate-all-proj-billing-report.csv | 509754247    | dbf2a67bfc6b609363f99bcf8d0c3799-30 | b1f79144c782e699e004e78f2da099e7 | s3://rti-test-bucket/aggregate-all-proj-billing-report.csv | 2020-01-01 21:05:40+00:00 | dg.1212/0e0877ba-731b-4ce9-b266-34b71e6d6322 | drs://dg.1212:dg.1212%2F0e0877ba-731b-4ce9-b266-34b71e6d6322 |
+| s3://rti-test-bucket/billing-budget-alert-email.png        | s3://rti-test-bucket/billing-budget-alert-email.png        | 1345755      | 2992b062c8ce8876cdcc552e233c6c3c    | 2992b062c8ce8876cdcc552e233c6c3c | s3://rti-test-bucket/billing-budget-alert-email.png        | 2020-01-01 21:05:52+00:00 | dg.1212/dfafc275-1206-4684-8368-512b4ae479ec | drs://dg.1212:dg.1212%2Fdfafc275-1206-4684-8368-512b4ae479ec |
+| s3://rti-test-bucket/var_report.xml                        | s3://rti-test-bucket/var_report.xml                        | 1380403      | 7845dda8786244538b5ebb826021af1d    | 7845dda8786244538b5ebb826021af1d | s3://rti-test-bucket/var_report.xml                        | 2020-01-01 21:05:56+00:00 | dg.1212/14cccdae-c671-4abe-b1fd-b288b15eff38 | drs://dg.1212:dg.1212%2F14cccdae-c671-4abe-b1fd-b288b15eff38 |
+| s3://rti-test-bucket/test.txt.gz                           | s3://rti-test-bucket/test.txt.gz                           | 924487       | e18ece94da761771c8bbdb9b8be3d0db    | e18ece94da761771c8bbdb9b8be3d0db | s3://rti-test-bucket/test.txt.gz                           | 2020-01-01 21:06:00+00:00 | dg.1212/e2ac1985-db23-4bfe-bfe1-07a476177c66 | drs://dg.1212:dg.1212%2Fe2ac1985-db23-4bfe-bfe1-07a476177c66 |
+| s3://rti-test-bucket/test.txt                              | s3://rti-test-bucket/test.txt                              | 79580051     | bc98ca9dfb02a387703603a447644e94-5  | 6ae3f98be14578ea5b3c6c712a442408 | s3://rti-test-bucket/test.txt                              | 2020-01-01 21:05:40+00:00 | dg.1212/5ee01ada-1f63-40ef-a6b2-dc3ce2aa0a03 | drs://dg.1212:dg.1212%2F5ee01ada-1f63-40ef-a6b2-dc3ce2aa0a03 | 
+-->
+
+## Reference
+Some helpful resources in troubleshooting common problems with the Google service account.
+
+- https://cloud.google.com/iam/docs/best-practices-service-accounts
+- https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
+- https://serverfault.com/questions/848580/how-to-use-google-application-credentials-with-gcloud-on-a-server
+- https://stackoverflow.com/questions/43278622/gcloud-auth-activate-service-account-error-please-ensure-provided-key-file-is
+- https://stackoverflow.com/questions/68290090/set-up-google-cloud-platform-gcp-authentication-for-terraform-cloud/74362252#74362252
+
+## Contact
+For additional information or assistance, please contact Ravi Mathur (rmathur@rti.org) or Stephen Hwang(shwang@rti.org).

--- a/transfer_s3_to_gcs/v1.0/Dockerfile
+++ b/transfer_s3_to_gcs/v1.0/Dockerfile
@@ -1,0 +1,26 @@
+# Use the official Google Cloud SDK image as the base image
+FROM --platform=linux/amd64 google/cloud-sdk:latest
+# FROM google/cloud-sdk:latest
+LABEL description='Initiate transfer of S3 objects to GCS bucket using Google service account'
+LABEL maintainer='Stephen Hwang <shwang@rti.org>'
+LABEL software-website="https://github.com/aws/aws-cli"
+LABEL software-version="v2"
+LABEL license="https://github.com/aws/aws-cli?tab=License-1-ov-file"
+LABEL reference="https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+
+# Install necessary tools, AWS CLI, Python, and clean up
+RUN apt-get update && \
+    apt-get install -y unzip curl && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws /var/lib/apt/lists/*
+
+# Set the working directory in the container
+WORKDIR /opt
+
+# Copy the local code to the container's working directory
+COPY ./opt/ /opt/
+
+# Make sure the scripts are executable
+RUN chmod +x /opt/*.sh

--- a/transfer_s3_to_gcs/v1.0/opt/configure_aws_cli.sh
+++ b/transfer_s3_to_gcs/v1.0/opt/configure_aws_cli.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo '>>> Configuring aws cli...'
+aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+aws configure set region $AWS_DEFAULT_REGION

--- a/transfer_s3_to_gcs/v1.0/opt/entrypoint.sh
+++ b/transfer_s3_to_gcs/v1.0/opt/entrypoint.sh
@@ -1,46 +1,21 @@
 #!/bin/bash
 
-# # Configure AWS CLI
-# echo "[[ configure_aws_cli.sh ]]"
-# bash /opt/configure_aws_cli.sh
-
-# # Get latest manifest file from S3
-# echo "[[ aws s3 - copy most recently generated manifest .tsv from s3://$S3_BUCKET]]"
-# TSV_FILENAME=$(aws s3 ls s3://$S3_BUCKET | grep ".*manifest.*tsv" | sort | tail -n 1 | awk '{print $4}')
-# aws s3 cp "s3://$S3_BUCKET/$TSV_FILENAME" "/opt/$TSV_FILENAME"
-# echo "Pulled {$TSV_FILENAME}"
-
 # Activate the Google Cloud service account with the credentials file
-# Check if NHLBI_FILE or NHLBI_JSON environment variables exist
+# Check if file or json environment variables exist
 if [ -n "$GC_ADC_FILE" ]; then
     echo "[[ Activating Google Cloud service account ]]"
     gcloud auth activate-service-account --key-file="$GC_ADC_FILE"
-    # Add the code to handle the case when the variables are set
+# If container binding is not supported, create temporary adc.json file
 elif [ -n "$GC_ADC_JSON" ]; then
     echo "--- GC_ADC_JSON detected ---"
     echo "[[ Create Google Service Account key file ]]"
     echo $GC_ADC_JSON > /opt/adc.json
     echo "[[ Activating Google Cloud service account ]]"
     gcloud auth activate-service-account --key-file="/opt/adc.json"
-
-    # Add the code to handle the case when the variables are not set
 else
     echo "GC_ADC_FILE or GC_ADC_JSON not detected."
     exit 1
 fi
-
-
-# # If container binding it not supported, create temporary adc.json file
-# echo "[[ Create Google Service Account key file ]]"
-# echo $GC_ADC_JSON > /opt/adc.json
-# echo "[[ Activating Google Cloud service account ]]"
-# gcloud auth activate-service-account --key-file="/opt/adc.json"
-
-# otherwise, set GOOGLE_APPLICATION_CREDENTIALS to the path of the service account key file
-# https://stackoverflow.com/questions/68290090/set-up-google-cloud-platform-gcp-authentication-for-terraform-cloud/74362252#74362252
-# export GOOGLE_APPLICATION_CREDENTIALS=${GC_ADC_FILE}
-# gcloud auth activate-service-account --key-file="$GC_ADC_FILE"
-
 echo "[[ Create temporary AWScreds.txt file ]]"
 echo "{ \"accessKeyId\": \"$AWS_ACCESS_KEY_ID\", \"secretAccessKey\": \"$AWS_SECRET_ACCESS_KEY\" }" > /opt/AWScreds.txt
 
@@ -54,26 +29,9 @@ gcloud transfer jobs create s3://"$S3_BUCKET" gs://"$S3_BUCKET" \
 
 echo "[[ Cleanup AWScreds.txt file ]]"
 rm /opt/AWScreds.txt
-# cat /opt/AWScreds.txt
 
-# echo "[[ Cleanup gs://$S3_BUCKET of manifest files ]]"
-# gsutil rm -a "gs://$S3_BUCKET/*manifest*"
-
-# # nih-nhlbi-rti-test-gcp-bucket.manifest.20240327030438
-# echo "[[ Generate manifest for gs://$S3_BUCKET ]]"
-# python3.9 /opt/generate_manifest_for_gcloud.py \
-#      --bucket $S3_BUCKET \
-#      --tsv "/opt/$TSV_FILENAME" \
-#      --threads 1
-
-# List the contents of the specified Google Cloud Storage bucket
-echo "[[ List manifest files in gs://$S3_BUCKET ]]"
-gsutil ls -r "gs://$S3_BUCKET/*manifest*"
-
-echo "[[ List all objects in gs://$S3_BUCKET ]]"
-gsutil ls -r "gs://$S3_BUCKET"
-
+# If temp adc.json was created, clean it up
 if [ -n "$GC_ADC_JSON" ]; then
-    echo "[[ Cleanup Google Service Account key file ]]"
+    echo "[[ Cleanup GAC key file ]]"
     rm /opt/adc.json
 fi

--- a/transfer_s3_to_gcs/v1.0/opt/entrypoint.sh
+++ b/transfer_s3_to_gcs/v1.0/opt/entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# # Configure AWS CLI
+# echo "[[ configure_aws_cli.sh ]]"
+# bash /opt/configure_aws_cli.sh
+
+# # Get latest manifest file from S3
+# echo "[[ aws s3 - copy most recently generated manifest .tsv from s3://$S3_BUCKET]]"
+# TSV_FILENAME=$(aws s3 ls s3://$S3_BUCKET | grep ".*manifest.*tsv" | sort | tail -n 1 | awk '{print $4}')
+# aws s3 cp "s3://$S3_BUCKET/$TSV_FILENAME" "/opt/$TSV_FILENAME"
+# echo "Pulled {$TSV_FILENAME}"
+
+# Activate the Google Cloud service account with the credentials file
+# Check if NHLBI_FILE or NHLBI_JSON environment variables exist
+if [ -n "$GC_ADC_FILE" ]; then
+    echo "[[ Activating Google Cloud service account ]]"
+    gcloud auth activate-service-account --key-file="$GC_ADC_FILE"
+    # Add the code to handle the case when the variables are set
+elif [ -n "$GC_ADC_JSON" ]; then
+    echo "--- GC_ADC_JSON detected ---"
+    echo "[[ Create Google Service Account key file ]]"
+    echo $GC_ADC_JSON > /opt/adc.json
+    echo "[[ Activating Google Cloud service account ]]"
+    gcloud auth activate-service-account --key-file="/opt/adc.json"
+
+    # Add the code to handle the case when the variables are not set
+else
+    echo "GC_ADC_FILE or GC_ADC_JSON not detected."
+    exit 1
+fi
+
+
+# # If container binding it not supported, create temporary adc.json file
+# echo "[[ Create Google Service Account key file ]]"
+# echo $GC_ADC_JSON > /opt/adc.json
+# echo "[[ Activating Google Cloud service account ]]"
+# gcloud auth activate-service-account --key-file="/opt/adc.json"
+
+# otherwise, set GOOGLE_APPLICATION_CREDENTIALS to the path of the service account key file
+# https://stackoverflow.com/questions/68290090/set-up-google-cloud-platform-gcp-authentication-for-terraform-cloud/74362252#74362252
+# export GOOGLE_APPLICATION_CREDENTIALS=${GC_ADC_FILE}
+# gcloud auth activate-service-account --key-file="$GC_ADC_FILE"
+
+echo "[[ Create temporary AWScreds.txt file ]]"
+echo "{ \"accessKeyId\": \"$AWS_ACCESS_KEY_ID\", \"secretAccessKey\": \"$AWS_SECRET_ACCESS_KEY\" }" > /opt/AWScreds.txt
+
+echo "[[ Initiate transfer from s3:// to gs://$S3_BUCKET ]]"
+gcloud transfer jobs create s3://"$S3_BUCKET" gs://"$S3_BUCKET" \
+    --name "$S3_BUCKET" \
+    --description "$S3_BUCKET" \
+    --source-creds-file /opt/AWScreds.txt \
+    --project "$GC_PROJECT" \
+    --no-enable-posix-transfer-logs
+
+echo "[[ Cleanup AWScreds.txt file ]]"
+rm /opt/AWScreds.txt
+# cat /opt/AWScreds.txt
+
+# echo "[[ Cleanup gs://$S3_BUCKET of manifest files ]]"
+# gsutil rm -a "gs://$S3_BUCKET/*manifest*"
+
+# # nih-nhlbi-rti-test-gcp-bucket.manifest.20240327030438
+# echo "[[ Generate manifest for gs://$S3_BUCKET ]]"
+# python3.9 /opt/generate_manifest_for_gcloud.py \
+#      --bucket $S3_BUCKET \
+#      --tsv "/opt/$TSV_FILENAME" \
+#      --threads 1
+
+# List the contents of the specified Google Cloud Storage bucket
+echo "[[ List manifest files in gs://$S3_BUCKET ]]"
+gsutil ls -r "gs://$S3_BUCKET/*manifest*"
+
+echo "[[ List all objects in gs://$S3_BUCKET ]]"
+gsutil ls -r "gs://$S3_BUCKET"
+
+if [ -n "$GC_ADC_JSON" ]; then
+    echo "[[ Cleanup Google Service Account key file ]]"
+    rm /opt/adc.json
+fi


### PR DESCRIPTION
# Description
This sets up an environment to create a transfer job (using Google's Cloud Storage Transfer Service) via a Google service account which ultimately results in creating a Google Storage (GS) bucket that mirrors a AWS S3 bucket.

<br>


### Dockerfile Structure and Organization:
- [x] Does the Dockerfile build?
- [x] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [x] Specific base image with a version tag, e.g., `FROM ubuntu:20.04` instead of `FROM ubuntu`.
- [x] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [x] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [x] `LABEL base-image="ubuntu:22.04"`
- [x] `LABEL description="Short description of the purpose of this image"`
- [x] `LABEL software-website="https://example.com"`
- [x] `LABEL software-version="1.0.0"`
- [x] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [x] Store scripts, files, and software tools ONLY in `/opt`. 
- [x] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [x] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [ ] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).

<br>

### Assign reviewer
- [x] Request review (default: @jaamarks)
