### PR TITLE
Seven Bridges File Tagging: Add pilot samples file capabilities

### DIFF
--- a/file_tag_sevenbridges/v1.1/Dockerfile
+++ b/file_tag_sevenbridges/v1.1/Dockerfile
@@ -1,0 +1,25 @@
+# Base image
+FROM rocker/tidyverse:4.4.1
+
+# Maintainer and author 
+LABEL maintainer="Caryn Willis <cdwillis@rti.org>"
+LABEL description="An R script using Seven Bridges API to tag files with RMIP file formatting."
+LABEL software-website="https://doi.org/10.32614/CRAN.package.sevenbridges2"
+LABEL software-version="0.2.0"
+LABEL license="https://www.apache.org/licenses/LICENSE-2.0"
+
+# Create working directory
+RUN mkdir -p /scratch
+WORKDIR /scratch
+
+# Install necessary R packages
+RUN Rscript -e 'install.packages(c("readr","tidyverse","openxlsx","sevenbridges2","tools","logr","stringr","optparse"), repos = "http://cran.us.r-project.org")'
+
+#Add to environment
+ENV PATH=$PATH:/opt/
+
+# Copy script
+COPY file_tagging.R /opt/file_tagging.R
+
+# Set default command to display help message
+CMD ["Rscript", "/opt/file_tagging.R", "-h"]

--- a/file_tag_sevenbridges/v1.1/README.md
+++ b/file_tag_sevenbridges/v1.1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+This Docker image contains a script to tag files within a project with the RMIP file formatting.
+
+### Inputs
+- Seven Bridges Developer token (Required)
+- Seven Bridges api endpoint (default = "https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2")
+- project ID e.g. "username/test-project" (Required)
+- folder (optional, use if wanting to tag a specific folder within a project)
+
+### Run
+```
+docker run -it -v $PWD:/scratch file_tag_sevenbridges:v1.0 Rscript file_tagging.R \
+  -t <token_here> \
+  -a <api_endpoint_here> \
+  -p <project_id_here> \
+  -f <folder_name_here>
+```
+
+### Files included
+
+- `Dockerfile`: the Docker file used to build this image
+- `file_tagging.R`: R script that serves as the main executable when the Docker container is run.  Expected behavior is to call the Seven Bridges API recursively on a project to collect the file ids within a project or folder and tag the files with the RMIP file tagging format. If any file does not match the RMIP file formatting, it is documented in the log file.
+
+File tagging documentation: https://bdcatalyst.freshdesk.com/support/discussions/topics/60000407796
+
+### Contact
+
+If you have any questions or feedback, please feel free to contact the maintainers of this project:
+
+- Caryn Willis, email: cdwillis@rti.org

--- a/file_tag_sevenbridges/v1.1/file_tagging.R
+++ b/file_tag_sevenbridges/v1.1/file_tagging.R
@@ -1,0 +1,137 @@
+library(readr)
+library(tidyverse)
+library(openxlsx)
+library(sevenbridges2)
+library(tools)
+library(logr)
+library(stringr)
+library(optparse)
+library(dplyr)
+
+option_list <- list(
+  make_option(c("-t", "--token"), type="character", default=NULL, 
+              help="SB token", metavar="character"),
+  make_option(c("-a", "--api_endpoint"), type="character", default="https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2", 
+              help="SB token [default= %default]", metavar="character"),
+  make_option(c("-p", "--project_id"), type="character", default=NULL, 
+              help="project ID [default= %default]", metavar="character"),
+  make_option(c("-f", "--folder"), type="character", default=NULL, 
+              help="folder [default= %default]", metavar="character")
+) 
+
+opt_parser <- OptionParser(option_list=option_list)
+opt <- parse_args(opt_parser)
+
+if(is.null(opt$token) | is.null(opt$project_id)){
+  stop("SB token and project ID are required to run file tagging.")
+}else{
+  token <- opt$token
+  project_id <- opt$project_id
+  api_endpoint <-opt$api_endpoint
+}
+
+
+if (!is.null(opt$folder)){
+  folder_name <- opt$folder
+}
+
+
+### functions ###
+extract_file_info <- function(project_id,parent_id=NA,parent_name="root", df_files) {
+  print(paste(project_id, parent_id,parent_name))
+  
+  if (is.na(parent_id)){
+    subdirectory_files <- a$files$query(project = project_id)
+  } else{
+    print(parent_id)
+    subdirectory_files <- a$files$query(parent = parent_id)
+    print(paste0("Starting folder search with file$id or parent_id: ", parent_id))
+  }
+  
+  for(file in subdirectory_files$items){
+    print(file$tags)
+    print(file)
+    data_row <- data.frame(
+      name = file$name,
+      type = file$type,
+      id = file$id
+    )
+    df_files <- bind_rows(df_files,data_row)
+    if (file$type == "folder") {
+      df_files <- extract_file_info(project_id = project_id,
+                                    parent_id = file$id,
+                                    parent_name = file$name,
+                                    df_files)
+      print(paste0("Exiting folder: ", file$name))
+      print("=====================================")
+    }
+  }
+  return(df_files)
+}
+####
+
+log_loc<-file.path("file_tagging.log")
+lf <- log_open(log_loc,logdir = FALSE, show_notes = FALSE)
+log_print(paste("File tagging starting...",Sys.time()))
+
+a <- Auth$new(token = token, url = api_endpoint)
+if (!is.null(opt$folder)){
+  folder_id<-a$files$query(project =project_id,name = folder_name)$items[[1]]$id
+}
+
+df_files_empty <- data.frame(
+  name = character(0),
+  upload_directory = character(0),
+  id = character(0)
+)
+
+if (!is.null(opt$folder)){
+  df_files_out <- extract_file_info(project_id= project_id, parent_id = folder_id,df_files = df_files_empty)
+}else{
+  df_files_out <- extract_file_info(project_id= project_id, parent_name="Root",df_files=df_files_empty)
+}
+df_files_out<-subset(df_files_out,type=='file')
+
+for (i in c(1:nrow(df_files_out))){
+  current_tags<-unlist(a$files$get(id=df_files_out$id[i])$tags)
+  file_name <- df_files_out$name[i]
+  file_name_base <- file_path_sans_ext(file_name)
+  file_ext <- file_ext(file_name)
+  
+  file_name_sep<- str_split(file_name_base,pattern = "_",simplify = TRUE)
+  if (length(file_name_sep)>2 & file_name_sep[3]=="PL"){
+    sample_id <- paste(file_name_sep[3:4],collapse = "_")
+    vial <- file_name_sep[5]
+    new_tags <- c(sample_id,vial)
+    if (length(current_tags)>=1){
+      tags <- unique(c(current_tags, new_tags))
+    }else{
+      tags <- new_tags
+    }
+    log_print(tags)
+    a$files$get(id=df_files_out$id[i])$add_tag(as.list(tags))
+    }else if (length(file_name_sep)<6 | file_name_sep[1]!="RMIP"){
+    log_print(paste("File", file_name, "is not formatted correctly. This file has not been tagged."), blank_after = FALSE)
+  }else{
+    log_print(paste("File", file_name, "is formatted correctly. Tagging..."), blank_after = FALSE)
+    participant_id <- paste(file_name_sep[1:3],collapse = "_")
+    sample_id <- paste(file_name_sep[4:5],collapse = "_")
+    vial <- file_name_sep[6]
+    #don't tag Allo participants with participant id
+    if(length(grep("Allo",participant_id)) > 0){
+      new_tags <- c(sample_id, vial, file_ext)
+    }else{
+      new_tags <- c(participant_id, sample_id, vial, file_ext)
+    }
+    
+    if (length(current_tags)>=1){
+      tags <- unique(c(current_tags, new_tags))
+    }else{
+      tags <- new_tags
+    }
+    log_print(tags)
+    a$files$get(id=df_files_out$id[i])$add_tag(as.list(tags))
+  }
+}
+
+log_close()


### PR DESCRIPTION
# Description
This PR tracks the addition of being able to tag pilot sample files that have a short file tag name to the file tagging tool on Seven Bridges. This will be released as v1.1.
<br>


### Dockerfile Structure and Organization:
- [ ] Does the Dockerfile build?
- [ ] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [ ] Specific base image with a version tag, e.g., `FROM ubuntu:20.04` instead of `FROM ubuntu`.
- [ ] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [ ] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [ ] `LABEL base-image="ubuntu:22.04"`
- [ ] `LABEL description="Short description of the purpose of this image"`
- [ ] `LABEL software-website="https://example.com"`
- [ ] `LABEL software-version="1.0.0"`
- [ ] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [ ] Store scripts, files, and software tools ONLY in `/opt`. 
- [ ] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [ ] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [ ] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).
