### PR TITLE
cellRanger extract: add zip to uncompressed option

### DIFF
--- a/cellranger_extract_rename/v1.1/rename_files.sh
+++ b/cellranger_extract_rename/v1.1/rename_files.sh
@@ -305,6 +305,7 @@ done
 
 [[ ${COMPRESSED_INPUT} == true ]] && echo_verbose "INFO: Copying ZIP file to output directory: $INPUT -> ${OUTPUT_DIR}/${LINKER}_${INPUT}"
 [[ ${COMPRESSED_INPUT} == true ]] && cp $INPUT ${OUTPUT_DIR}/${LINKER}_${INPUT_NAME}.zip
+[[ ${COMPRESSED_INPUT} == false ]] && zip -r ${OUTPUT_DIR}/${LINKER}_outs.zip ${INPUT_NAME} -x "${FILE_LIST[@]}"
 
 if [[ ${TMP_OUTPUT_DIR_EXISTS} == true ]]; then
   echo_verbose "INFO: Removing TMP_OUTPUT_DIR"


### PR DESCRIPTION
# Description
If compressed zip file is given as input, zip is copied to output. This update replicates this action for when uncompressed directory is given as input by compressing input except extracted files.

<br>


### Dockerfile Structure and Organization:
- [x] Does the Dockerfile build?
- [x] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [x] Specific base image with a version tag, e.g., `FROM ubuntu:20.04` instead of `FROM ubuntu`.
- [x] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [x] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [x] `LABEL base-image="ubuntu:22.04"`
- [x] `LABEL description="Short description of the purpose of this image"`
- [x] `LABEL software-website="https://example.com"`
- [x] `LABEL software-version="1.0.0"`
- [x] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [x] Store scripts, files, and software tools ONLY in `/opt`. 
- [x] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [x] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [x] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).
