### PR TITLE
cell_ranger_extract: Switch back to move function instead of copy

### DIFF
--- a/cellranger_extract_rename/v1.1/rename_files.sh
+++ b/cellranger_extract_rename/v1.1/rename_files.sh
@@ -261,7 +261,7 @@ prefix="${LINKER}"  # Replace with the desired prefix
 find ${OUTPUT_DIR} -type f -print0 | while IFS= read -r -d $'\0' file; do
   dir_path=$(dirname "$file")
   file_name=$(basename "$file")
-  cp "$file" "$dir_path/${prefix}_${file_name}"
+  mv "$file" "$dir_path/${prefix}_${file_name}"
   echo_verbose "Renamed file '$file' to '${prefix}_${file_name}'"
 done
 


### PR DESCRIPTION
# Description
Fix copy files issue which creates duplicate files. Switching back to mv to rename files. 
<br>


### Dockerfile Structure and Organization:
- [x] Does the Dockerfile build?
- [x] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [x] Specific base image with a version tag, e.g., `FROM ubuntu:20.04` instead of `FROM ubuntu`.
- [x] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [x] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [x] `LABEL base-image="ubuntu:22.04"`
- [x] `LABEL description="Short description of the purpose of this image"`
- [x] `LABEL software-website="https://example.com"`
- [x] `LABEL software-version="1.0.0"`
- [x] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [x] Store scripts, files, and software tools ONLY in `/opt`. 
- [x] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [x] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [ ] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).
