### PR TITLE
feat: create new image for latest version of plink2

### DIFF
--- a/plink/v2.0.0-a.6.15/Dockerfile
+++ b/plink/v2.0.0-a.6.15/Dockerfile
@@ -1,0 +1,32 @@
+# Base image
+FROM ubuntu:24.04
+
+# Maintainer and author
+LABEL maintainer="Jesse Marks <jmarks@rti.org>" \
+      base-image="ubuntu:24.04" \
+      description="Plink2 a free and open-source whole-genome association analysis toolset." \
+      software-website="https://www.cog-genomics.org/plink/2.0/" \
+      software-version="v2.0.0-a.6.15" \
+      git-commit="6adf7a57da1123104d23651fb12573a0842321b9"
+
+# Basic Ubuntu setup with combined commands
+RUN apt update && apt install -y \
+        less \
+        vim \
+        wget \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+#### Install Plink dependencies and Plink ####
+RUN wget https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_amd_avx2_20250604.zip \
+    && unzip /plink2_linux_amd_avx2_20250604.zip -d plink_tmp \
+    && cp /plink_tmp/plink2 /opt/ \
+    && rm -rf plink2_linux_x86_64_20250604.zip plink_tmp
+
+# Set working directory and path
+WORKDIR /
+ENV PATH=pkg-config:$PATH:/opt/
+
+# Using CMD instead of ENTRYPOINT allows for easy interactive login with bash command.
+# This way, overriding with --entrypoint is not necessary when logging in interactively.
+CMD ["plink2"]

--- a/plink/v2.0.0-a.6.15/README.md
+++ b/plink/v2.0.0-a.6.15/README.md
@@ -1,0 +1,15 @@
+# plink2 Docker Image
+
+This Docker image contains the `plink2` binary (version 2.0.0-a.6.15, 2025-06-04, AVX2 build), downloaded from:<br>
+🔗 https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_amd_avx2_20250604.zip
+
+## Usage
+
+Run `plink2` using Docker:
+
+```bash
+docker run --rm -v $(pwd):/data rtibiocloud/plink:v2.0.0-a.6.15_<latest-commit> plink2 --help
+```
+
+## Contact
+For help contact Jesse Marks (jmarks@rti.org).


### PR DESCRIPTION
# Description
Create Docker image of the latest version of Plink2. This version includes the `--check-sex` feature that we wanted, among other update.

<br>


### Dockerfile Structure and Organization:
- [X] Does the Dockerfile build?
- [X] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [X] Specific base image with a version tag, e.g., `FROM ubuntu:20.04` instead of `FROM ubuntu`.
- [X] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [X] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [X] `LABEL base-image="ubuntu:22.04"`
- [x] `LABEL description="Short description of the purpose of this image"`
- [x] `LABEL software-website="https://example.com"`
- [x] `LABEL software-version="1.0.0"`
- [x] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [x] Store scripts, files, and software tools ONLY in `/opt`. 
- [x] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [x] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [x] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).
