### PR TITLE
dnam_processing_qc v1.0: SnowParam on all platforms

### DIFF
--- a/dnam_processing_qc/v1.0/Dockerfile
+++ b/dnam_processing_qc/v1.0/Dockerfile
@@ -26,10 +26,15 @@ RUN Rscript -e 'install.packages("pak", repos = "https://cloud.r-project.org")' 
 
 # Install necessary Bioconductor packages (pinned versions)
 RUN Rscript -e 'BiocManager::install( \
-    c("sesame", "sesameData", "BiocParallel", "minfi", "wateRmelon", "PCAtools"), \
+    c("sesame", "sesameData", "BiocParallel", "minfi", "wateRmelon", "PCAtools", \
+      "IlluminaHumanMethylationEPICmanifest", \
+      "IlluminaHumanMethylationEPICv2manifest", \
+      "IlluminaHumanMethylation450kmanifest", \
+      "IlluminaHumanMethylation27kmanifest"), \
     ask = FALSE, update = FALSE)'
 # sesame==1.30.1, sesameData==1.30.0, BiocParallel==1.46.0,
 # minfi==1.58.0, wateRmelon==2.18.0, PCAtools==2.24.0
+# manifests for EPIC / EPICv2 / HM450 / HM27 (required by minfi::read.metharray)
 
 # Add to environment
 ENV PATH=$PATH:/opt/

--- a/dnam_processing_qc/v1.0/dnam_processing_qc.R
+++ b/dnam_processing_qc/v1.0/dnam_processing_qc.R
@@ -134,9 +134,11 @@ rm(matched_samples)
 
 logr::sep("Reading in idat files")
 
-# Read in the idat files so that we can get beadcount
+# Read in the idat files so that we can get beadcount.
+# force = TRUE allows mixing IDATs with slightly different array sizes (e.g.
+# minor manufacturing revisions of the same platform).
 rgchannelset <- minfi::read.metharray(
-  basenames = matching_files, extended = TRUE
+  basenames = matching_files, extended = TRUE, force = TRUE
 )
 # Store the beadcount information for later.
 beadcount <- wateRmelon::beadcount(rgchannelset)

--- a/dnam_processing_qc/v1.0/dnam_processing_qc.R
+++ b/dnam_processing_qc/v1.0/dnam_processing_qc.R
@@ -35,15 +35,13 @@ lf <- logr::log_open(
 # On exit, close the log file
 on.exit(logr::log_close())
 
-# Set up a parallel backend that works on all platforms (including Windows).
-# MulticoreParam uses forking and is not supported on Windows; SnowParam uses
-# sockets and works everywhere.
+# Set up a parallel backend. SnowParam (socket-based) is used on all platforms
+# because MulticoreParam has a known bug ("wrong args for environment
+# subassignment" in the reducer) that triggers when workers return SigDF
+# objects. SnowParam avoids this at a small overhead cost from serializing
+# objects between workers.
 n_workers <- max(1L, parallel::detectCores() - 2L)
-if (.Platform$OS.type == "windows") {
-  bpparam <- BiocParallel::SnowParam(workers = n_workers)
-} else {
-  bpparam <- BiocParallel::MulticoreParam(workers = n_workers)
-}
+bpparam <- BiocParallel::SnowParam(workers = n_workers)
 
 # Write the input parameters to the log file.
 logr::sep("Input parameters")

--- a/dnam_processing_qc/v1.0/dnam_processing_qc.R
+++ b/dnam_processing_qc/v1.0/dnam_processing_qc.R
@@ -144,6 +144,11 @@ rgchannelset <- minfi::read.metharray(
 beadcount <- wateRmelon::beadcount(rgchannelset)
 rm(rgchannelset)
 
+# Warm up the sesame data cache with a single serial call before parallel
+# reads. Without this, parallel workers can race on ExperimentHub and throw
+# "wrong args for environment subassignment" (BiocParallel reducer errors).
+invisible(sesame::readIDATpair(matching_files[[1]], platform = platform))
+
 # Read in the idat files using sesame to get the SDF objects for each sample.
 sdf <- BiocParallel::bplapply(
   matching_files, sesame::readIDATpair, platform = platform,


### PR DESCRIPTION
# Description

Switches the parallel backend in dnam_processing_qc.R from an OS-conditional MulticoreParam/SnowParam to unconditional SnowParam. MulticoreParam has a reducer bug ("wrong args for environment subassignment") that triggers when returning SigDF objects.

<br>


### Dockerfile Structure and Organization:
- [ ] Does the Dockerfile build?
- [ ] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [ ] Specific base image with a version tag, e.g., `FROM ubuntu:24.04` instead of `FROM ubuntu`.
- [ ] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [ ] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [ ] `LABEL base-image="ubuntu:24.04"`
- [ ] `LABEL description="Short description of the purpose of this image"`
- [ ] `LABEL software-website="https://example.com"`
- [ ] `LABEL software-version="1.0.0"`
- [ ] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [ ] Store scripts, files, and software tools ONLY in `/opt`. 
- [ ] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [ ] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [ ] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).
